### PR TITLE
Remove hardcoded legend position

### DIFF
--- a/galeritas/stacked_percentage_bar_plot.py
+++ b/galeritas/stacked_percentage_bar_plot.py
@@ -116,7 +116,7 @@ def stacked_percentage_bar_plot(
     ax.set_xlabel(categorical_feature)
     ax.set_ylabel("%")
 
-    ax.legend(loc='upper right', **legend_kwargs)
+    ax.legend(**legend_kwargs)
 
     plt.grid(True, alpha=0.9, linestyle='--', axis='y')
 


### PR DESCRIPTION
## Context
The `stacked_percentage_bar_plot` currently has a hardcoded legend setting for its location, which may harm the user experience. This PR fixes it by removing the hardcoded position.

## What has changed?
* Remove hardcoded `loc` property from `main/galeritas/stacked_percentage_bar_plot.py` file

<!-- Thanks for sending a pull request (PR)! Before submitting a PR, please fill out the blanks below and check our contributing documentation for any questions or let us know here if you need any help: https://galeritas.readthedocs.io/en/latest/contributing.html -->

### Description
<!-- What does this implement/fix? Please explain the changes you made here. -->

### Does this close any currently open issues?
<!-- If applicable, please reference the open issues here -->

### Pull request type
<!-- Please check the type of change your PR introduces -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe): 

### References
<!-- If applicable, please add here all the references used to develop the solution -->

### Checklist
🚨 **Before submitting your pull request, please review the following checklist:**
<!-- Check all those that are applicable and complete -->

- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (new and existing ones)
- [ ] Extended the documentation, if necessary
- [ ] All the previous sections were filled with a clear description
- [ ] Assign yourself or/and the persons responsible for the modifications



